### PR TITLE
Use DOMReady to initialise the bridge library

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It handle Turbolinks events to properly clean up the DOM from Alpine generated c
 ## Install
 
 ### From CDN
-Just include `<script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine-turbolinks-adapter@0.1.x/dist/alpine-turbolinks-adapter.min.js" defer></script>` along with your Alpine script in your page.
+Just include `<script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine-turbolinks-adapter@0.1.x/dist/alpine-turbolinks-adapter.min.js" defer></script>` before your Alpine script in your page.
 
 ### From NPM
  Install the package
@@ -15,6 +15,6 @@ npm i alpine-turbolinks-adapter
 ```
 Include it in your script along with Alpine JS.
 ```javascript
-import 'alpinejs'
 import 'alpine-turbolinks-adapter'
+import 'alpinejs'
 ```

--- a/dist/alpine-turbolinks-adapter.esm.js
+++ b/dist/alpine-turbolinks-adapter.esm.js
@@ -10,25 +10,20 @@ function isValidVersion(required, current) {
 
   return true;
 }
+function domReady(callback) {
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", callback);
+  } else {
+    callback();
+  }
+}
 
 class Bridge {
   init() {
-    const initAlpine = window.deferLoadingAlpine || (callback => callback());
+    this.setAlpine(window.Alpine); // eslint-disable-line no-undef
 
-    window.deferLoadingAlpine = callback => {
-      this.setAlpine(window.Alpine); // eslint-disable-line no-undef
-
-      document.addEventListener('turbolinks:load', () => {
-        // Tag all cloaked elements on first page load.
-        this.tagCloakedElements(document.body);
-        this.configureEventHandlers(); // Alpine needs to wait until after page load because it immediatly
-        // initializes components, which will remove the x-cloak attribute.
-
-        initAlpine(callback);
-      }, {
-        once: true
-      });
-    };
+    this.tagCloakedElements(document.body);
+    this.configureEventHandlers();
   }
 
   setAlpine(reference) {
@@ -76,6 +71,13 @@ class Bridge {
     });
   }
 
+  restoreCloakAttributes() {
+    document.body.querySelectorAll('[data-alpine-was-cloaked]').forEach(el => {
+      el.setAttribute('x-cloak', '');
+      el.removeAttribute('data-alpine-was-cloaked');
+    });
+  }
+
   configureEventHandlers() {
     document.addEventListener('turbolinks:load', () => {
       // Once Turbolinks finished is magic, we initialise Alpine on the new page
@@ -102,20 +104,24 @@ class Bridge {
     // of a better option.
     // Note, we can't remove any Alpine generated element as yet because if they live inside an element
     // marked as data-turbolinks-permanent they need to be copied into the next page.
-    // The coping process happens somewhere between before-cache and before-render.
+    // The copying process happens somewhere between before-cache and before-render.
 
     document.addEventListener('turbolinks:before-cache', () => {
       this.alpine.pauseMutationObserver = true;
       this.tagAlpineGeneratedElements(document.body); // Cloak any elements again that were tagged when the page was loaded
 
-      document.body.querySelectorAll('[data-alpine-was-cloaked]').forEach(el => {
-        el.setAttribute('x-cloak', '');
-        el.removeAttribute('data-alpine-was-cloaked');
-      });
+      this.restoreCloakAttributes();
     });
   }
 
 }
 
-const bridge = new Bridge();
-bridge.init();
+const initAlpine = window.deferLoadingAlpine || (callback => callback());
+
+window.deferLoadingAlpine = callback => {
+  domReady(() => {
+    const bridge = new Bridge();
+    bridge.init();
+    initAlpine(callback);
+  });
+};

--- a/dist/alpine-turbolinks-adapter.esm.js
+++ b/dist/alpine-turbolinks-adapter.esm.js
@@ -12,8 +12,23 @@ function isValidVersion(required, current) {
 }
 
 class Bridge {
-  constructor() {
-    this.setAlpine(window.Alpine); // eslint-disable-line no-undef
+  init() {
+    const initAlpine = window.deferLoadingAlpine || (callback => callback());
+
+    window.deferLoadingAlpine = callback => {
+      this.setAlpine(window.Alpine); // eslint-disable-line no-undef
+
+      document.addEventListener('turbolinks:load', () => {
+        // Tag all cloaked elements on first page load.
+        this.tagCloakedElements(document.body);
+        this.configureEventHandlers(); // Alpine needs to wait until after page load because it immediatly
+        // initializes components, which will remove the x-cloak attribute.
+
+        initAlpine(callback);
+      }, {
+        once: true
+      });
+    };
   }
 
   setAlpine(reference) {
@@ -31,12 +46,40 @@ class Bridge {
     });
   }
 
-  init() {
-    // Tag all cloaked elements on page load.
-    this.tagCloakedElements(document.body); // Once Turbolinks finished is magic, we initialise Alpine on the new page
-    // and resume the observer
+  removeAlpineGeneratedElements(node) {
+    node.querySelectorAll('[data-alpine-generated-me]').forEach(el => {
+      el.removeAttribute('data-alpine-generated-me');
 
+      if (typeof el.__x_for_key === 'undefined' && typeof el.__x_inserted_me === 'undefined') {
+        el.remove();
+      }
+    });
+  }
+
+  tagAlpineGeneratedElements(node) {
+    node.querySelectorAll('[x-for],[x-if]').forEach(el => {
+      if (el.hasAttribute('x-for')) {
+        let nextEl = el.nextElementSibling;
+
+        while (nextEl && nextEl.__x_for_key !== 'undefined') {
+          const currEl = nextEl;
+          nextEl = nextEl.nextElementSibling;
+          currEl.setAttribute('data-alpine-generated-me', true);
+        }
+      } else if (el.hasAttribute('x-if')) {
+        const ifEl = el.nextElementSibling;
+
+        if (ifEl && typeof ifEl.__x_inserted_me !== 'undefined') {
+          ifEl.setAttribute('data-alpine-generated-me', true);
+        }
+      }
+    });
+  }
+
+  configureEventHandlers() {
     document.addEventListener('turbolinks:load', () => {
+      // Once Turbolinks finished is magic, we initialise Alpine on the new page
+      // and resume the observer
       this.alpine.discoverUninitializedComponents(el => {
         this.alpine.initializeComponent(el);
       });
@@ -48,17 +91,9 @@ class Bridge {
     // and custom properties and we don't want to reset them.
 
     document.addEventListener('turbolinks:before-render', event => {
-      event.data.newBody.querySelectorAll('[data-alpine-generated-me]').forEach(el => {
-        el.removeAttribute('data-alpine-generated-me');
+      this.removeAlpineGeneratedElements(event.data.newBody); // When we get a new document body tag any cloaked elements so we can cloak
+      // them again before caching.
 
-        if (typeof el.__x_for_key === 'undefined' && typeof el.__x_inserted_me === 'undefined') {
-          el.remove();
-        }
-      });
-    }); // When we get a new document body tag any cloaked elements so we can cloak
-    // them again before caching.
-
-    document.addEventListener('turbolinks:before-render', event => {
       this.tagCloakedElements(event.data.newBody);
     }); // Pause the the mutation observer to avoid data races, it will be resumed by the turbolinks:load event.
     // We mark as `data-alpine-generated-m` all elements that are crated by an Alpine templating directives.
@@ -71,26 +106,8 @@ class Bridge {
 
     document.addEventListener('turbolinks:before-cache', () => {
       this.alpine.pauseMutationObserver = true;
-      document.body.querySelectorAll('[x-for],[x-if]').forEach(el => {
-        if (el.hasAttribute('x-for')) {
-          let nextEl = el.nextElementSibling;
+      this.tagAlpineGeneratedElements(document.body); // Cloak any elements again that were tagged when the page was loaded
 
-          while (nextEl && nextEl.__x_for_key !== 'undefined') {
-            const currEl = nextEl;
-            nextEl = nextEl.nextElementSibling;
-            currEl.setAttribute('data-alpine-generated-me', true);
-          }
-        } else if (el.hasAttribute('x-if')) {
-          const ifEl = el.nextElementSibling;
-
-          if (ifEl && typeof ifEl.__x_inserted_me !== 'undefined') {
-            ifEl.setAttribute('data-alpine-generated-me', true);
-          }
-        }
-      });
-    }); // Cloak any elements again that were tagged when the page was loaded
-
-    document.addEventListener('turbolinks:before-cache', () => {
       document.body.querySelectorAll('[data-alpine-was-cloaked]').forEach(el => {
         el.setAttribute('x-cloak', '');
         el.removeAttribute('data-alpine-was-cloaked');

--- a/dist/alpine-turbolinks-adapter.js
+++ b/dist/alpine-turbolinks-adapter.js
@@ -27,11 +27,20 @@
       }
 
       this.alpine = reference;
+    } // Tag cloaked elements so we can cloak them again before caching
+
+
+    tagCloakedElements(node) {
+      node.querySelectorAll('[x-cloak]').forEach(el => {
+        el.setAttribute('data-alpine-was-cloaked', '');
+      });
     }
 
     init() {
-      // Once Turbolinks finished is magic, we initialise Alpine on the new page
+      // Tag all cloaked elements on page load.
+      this.tagCloakedElements(document.body); // Once Turbolinks finished is magic, we initialise Alpine on the new page
       // and resume the observer
+
       document.addEventListener('turbolinks:load', () => {
         this.alpine.discoverUninitializedComponents(el => {
           this.alpine.initializeComponent(el);
@@ -51,6 +60,11 @@
             el.remove();
           }
         });
+      }); // When we get a new document body tag any cloaked elements so we can cloak
+      // them again before caching.
+
+      document.addEventListener('turbolinks:before-render', event => {
+        this.tagCloakedElements(event.data.newBody);
       }); // Pause the the mutation observer to avoid data races, it will be resumed by the turbolinks:load event.
       // We mark as `data-alpine-generated-m` all elements that are crated by an Alpine templating directives.
       // The reason is that turbolinks caches pages using cloneNode which removes listeners and custom properties
@@ -78,6 +92,13 @@
               ifEl.setAttribute('data-alpine-generated-me', true);
             }
           }
+        });
+      }); // Cloak any elements again that were tagged when the page was loaded
+
+      document.addEventListener('turbolinks:before-cache', () => {
+        document.body.querySelectorAll('[data-alpine-was-cloaked]').forEach(el => {
+          el.setAttribute('x-cloak', '');
+          el.removeAttribute('data-alpine-was-cloaked');
         });
       });
     }

--- a/dist/alpine-turbolinks-adapter.js
+++ b/dist/alpine-turbolinks-adapter.js
@@ -15,25 +15,20 @@
 
     return true;
   }
+  function domReady(callback) {
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", callback);
+    } else {
+      callback();
+    }
+  }
 
   class Bridge {
     init() {
-      const initAlpine = window.deferLoadingAlpine || (callback => callback());
+      this.setAlpine(window.Alpine); // eslint-disable-line no-undef
 
-      window.deferLoadingAlpine = callback => {
-        this.setAlpine(window.Alpine); // eslint-disable-line no-undef
-
-        document.addEventListener('turbolinks:load', () => {
-          // Tag all cloaked elements on first page load.
-          this.tagCloakedElements(document.body);
-          this.configureEventHandlers(); // Alpine needs to wait until after page load because it immediatly
-          // initializes components, which will remove the x-cloak attribute.
-
-          initAlpine(callback);
-        }, {
-          once: true
-        });
-      };
+      this.tagCloakedElements(document.body);
+      this.configureEventHandlers();
     }
 
     setAlpine(reference) {
@@ -81,6 +76,13 @@
       });
     }
 
+    restoreCloakAttributes() {
+      document.body.querySelectorAll('[data-alpine-was-cloaked]').forEach(el => {
+        el.setAttribute('x-cloak', '');
+        el.removeAttribute('data-alpine-was-cloaked');
+      });
+    }
+
     configureEventHandlers() {
       document.addEventListener('turbolinks:load', () => {
         // Once Turbolinks finished is magic, we initialise Alpine on the new page
@@ -107,22 +109,26 @@
       // of a better option.
       // Note, we can't remove any Alpine generated element as yet because if they live inside an element
       // marked as data-turbolinks-permanent they need to be copied into the next page.
-      // The coping process happens somewhere between before-cache and before-render.
+      // The copying process happens somewhere between before-cache and before-render.
 
       document.addEventListener('turbolinks:before-cache', () => {
         this.alpine.pauseMutationObserver = true;
         this.tagAlpineGeneratedElements(document.body); // Cloak any elements again that were tagged when the page was loaded
 
-        document.body.querySelectorAll('[data-alpine-was-cloaked]').forEach(el => {
-          el.setAttribute('x-cloak', '');
-          el.removeAttribute('data-alpine-was-cloaked');
-        });
+        this.restoreCloakAttributes();
       });
     }
 
   }
 
-  const bridge = new Bridge();
-  bridge.init();
+  const initAlpine = window.deferLoadingAlpine || (callback => callback());
+
+  window.deferLoadingAlpine = callback => {
+    domReady(() => {
+      const bridge = new Bridge();
+      bridge.init();
+      initAlpine(callback);
+    });
+  };
 
 })));

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,11 @@
 import Bridge from './bridge'
+import { domReady } from './utils'
 
-const bridge = new Bridge()
-bridge.init()
+const initAlpine = window.deferLoadingAlpine || ((callback) => callback())
+window.deferLoadingAlpine = (callback) => {
+  domReady(() => {
+    const bridge = new Bridge()
+    bridge.init()
+    initAlpine(callback)
+  })
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,3 +8,11 @@ export function isValidVersion (required, current) {
   }
   return true
 }
+
+export function domReady (callback) {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', callback)
+  } else {
+    callback()
+  }
+}

--- a/tests/integration/cloak.spec.js
+++ b/tests/integration/cloak.spec.js
@@ -1,0 +1,21 @@
+/* global describe, it, cy */
+
+describe('x-cloak directives', () => {
+  it('should tag x-cloak items on first page load', () => {
+    cy.visit('/tests/res/cloak/index.html')
+
+    // Check element was tagged
+    cy.get('span').should('have.attr', 'data-alpine-was-cloaked')
+  })
+
+  it('should tag x-cloak items when navigating with turbolinks', () => {
+    cy.visit('/tests/res/cloak/index.html')
+
+    // Navigate to the second page
+    cy.get('a').click()
+    cy.url().should('equal', 'http://127.0.0.1:8080/tests/res/cloak/target.html')
+
+    // Check element was tagged
+    cy.get('span').should('have.attr', 'data-alpine-was-cloaked')
+  })
+})

--- a/tests/res/cloak/index.html
+++ b/tests/res/cloak/index.html
@@ -1,0 +1,16 @@
+<html>
+  <head>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.2.0/turbolinks.js" integrity="sha256-iM4Yzi/zLj/IshPWMC1IluRxTtRjMqjPGd97TZ9yYpU=" crossorigin="anonymous"></script>
+      <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
+      <script src="/dist/alpine-turbolinks-adapter.js" defer></script>
+  </head>
+
+  <body>
+    <a href="/tests/res/cloak/target.html">go to target</a>
+
+    <div x-data="{ open: false }">
+      <button id='toggler' @click="open = true">Opener</button>
+      <span x-show="open" x-cloak>Hidden</span>
+    </div>
+  </body>
+</html>

--- a/tests/res/cloak/index.html
+++ b/tests/res/cloak/index.html
@@ -1,8 +1,8 @@
 <html>
   <head>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.2.0/turbolinks.js" integrity="sha256-iM4Yzi/zLj/IshPWMC1IluRxTtRjMqjPGd97TZ9yYpU=" crossorigin="anonymous"></script>
-      <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
-      <script src="/dist/alpine-turbolinks-adapter.js" defer></script>
+      <script src="/dist/alpine-turbolinks-adapter.js"></script>
+      <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js"></script>
   </head>
 
   <body>

--- a/tests/res/cloak/target.html
+++ b/tests/res/cloak/target.html
@@ -1,8 +1,8 @@
 <html>
   <head>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.2.0/turbolinks.js" integrity="sha256-iM4Yzi/zLj/IshPWMC1IluRxTtRjMqjPGd97TZ9yYpU=" crossorigin="anonymous"></script>
-      <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
       <script src="/dist/alpine-turbolinks-adapter.js" defer></script>
+      <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
   </head>
 
   <body>

--- a/tests/res/cloak/target.html
+++ b/tests/res/cloak/target.html
@@ -1,0 +1,16 @@
+<html>
+  <head>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.2.0/turbolinks.js" integrity="sha256-iM4Yzi/zLj/IshPWMC1IluRxTtRjMqjPGd97TZ9yYpU=" crossorigin="anonymous"></script>
+      <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
+      <script src="/dist/alpine-turbolinks-adapter.js" defer></script>
+  </head>
+
+  <body>
+    <a href="/tests/res/cloak/index.html">go to index</a>
+
+    <div x-data="{ open: false }">
+      <button id='toggler' @click="open = true">Opener</button>
+      <span x-show="open" x-cloak>Hidden</span>
+    </div>
+  </body>
+</html>

--- a/tests/res/for/index.html
+++ b/tests/res/for/index.html
@@ -1,8 +1,8 @@
 <html>
   <head>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.2.0/turbolinks.js" integrity="sha256-iM4Yzi/zLj/IshPWMC1IluRxTtRjMqjPGd97TZ9yYpU=" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
     <script src="/dist/alpine-turbolinks-adapter.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
   </head>
 
   <body>

--- a/tests/res/for/target.html
+++ b/tests/res/for/target.html
@@ -1,8 +1,8 @@
 <html>
   <head>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.2.0/turbolinks.js" integrity="sha256-iM4Yzi/zLj/IshPWMC1IluRxTtRjMqjPGd97TZ9yYpU=" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
     <script src="/dist/alpine-turbolinks-adapter.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
   </head>
 
   <body>

--- a/tests/res/if/index.html
+++ b/tests/res/if/index.html
@@ -1,8 +1,8 @@
 <html>
   <head>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.2.0/turbolinks.js" integrity="sha256-iM4Yzi/zLj/IshPWMC1IluRxTtRjMqjPGd97TZ9yYpU=" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
     <script src="/dist/alpine-turbolinks-adapter.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
   </head>
 
   <body>

--- a/tests/res/if/target.html
+++ b/tests/res/if/target.html
@@ -1,8 +1,8 @@
 <html>
   <head>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.2.0/turbolinks.js" integrity="sha256-iM4Yzi/zLj/IshPWMC1IluRxTtRjMqjPGd97TZ9yYpU=" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
     <script src="/dist/alpine-turbolinks-adapter.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
   </head>
 
   <body>

--- a/tests/res/permanent-for/index.html
+++ b/tests/res/permanent-for/index.html
@@ -1,8 +1,8 @@
 <html>
   <head>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.2.0/turbolinks.js" integrity="sha256-iM4Yzi/zLj/IshPWMC1IluRxTtRjMqjPGd97TZ9yYpU=" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
     <script src="/dist/alpine-turbolinks-adapter.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
   </head>
 
   <body>

--- a/tests/res/permanent-for/target.html
+++ b/tests/res/permanent-for/target.html
@@ -1,8 +1,8 @@
 <html>
   <head>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.2.0/turbolinks.js" integrity="sha256-iM4Yzi/zLj/IshPWMC1IluRxTtRjMqjPGd97TZ9yYpU=" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
     <script src="/dist/alpine-turbolinks-adapter.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
   </head>
 
   <body>

--- a/tests/res/permanent/index.html
+++ b/tests/res/permanent/index.html
@@ -1,8 +1,8 @@
 <html>
   <head>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.2.0/turbolinks.js" integrity="sha256-iM4Yzi/zLj/IshPWMC1IluRxTtRjMqjPGd97TZ9yYpU=" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
     <script src="/dist/alpine-turbolinks-adapter.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
   </head>
 
   <body>

--- a/tests/res/permanent/target.html
+++ b/tests/res/permanent/target.html
@@ -1,8 +1,8 @@
 <html>
   <head>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.2.0/turbolinks.js" integrity="sha256-iM4Yzi/zLj/IshPWMC1IluRxTtRjMqjPGd97TZ9yYpU=" crossorigin="anonymous"></script>
-      <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
       <script src="/dist/alpine-turbolinks-adapter.js" defer></script>
+      <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
   </head>
 
   <body>


### PR DESCRIPTION
If it works, I think we should go for an approach like this one.
Benefits:
- We won't set any listener if Alpine doesn't start for any reason (people just added this library by mistake to the wrong page)
- We won't stop Alpine from starting if something goes wrong with turbolinks:load.
- Everything should kick in slightly earlier.